### PR TITLE
Add a `LogLevel.fromString` method

### DIFF
--- a/core/shared/src/main/scala/org/typelevel/log4cats/extras/LogLevel.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/extras/LogLevel.scala
@@ -25,6 +25,15 @@ object LogLevel {
   case object Info extends LogLevel
   case object Debug extends LogLevel
   case object Trace extends LogLevel
+  
+  def fromString(s: String): Option[LogLevel] = s.toLowerCase match {
+    case "error" => Some(LogLevel.Error)
+    case "warn"  => Some(LogLevel.Warn)
+    case "info"  => Some(LogLevel.Info)
+    case "debug" => Some(LogLevel.Debug)
+    case "trace" => Some(LogLevel.Trace)
+    case _       => None
+  }
 
   implicit val logLevelShow: Show[LogLevel] = Show.show[LogLevel] {
     case Error => "LogLevel.Error"

--- a/core/shared/src/main/scala/org/typelevel/log4cats/extras/LogLevel.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/extras/LogLevel.scala
@@ -25,14 +25,19 @@ object LogLevel {
   case object Info extends LogLevel
   case object Debug extends LogLevel
   case object Trace extends LogLevel
-  
+
   def fromString(s: String): Option[LogLevel] = s.toLowerCase match {
     case "error" => Some(LogLevel.Error)
-    case "warn"  => Some(LogLevel.Warn)
-    case "info"  => Some(LogLevel.Info)
+    case "warn" => Some(LogLevel.Warn)
+    case "info" => Some(LogLevel.Info)
     case "debug" => Some(LogLevel.Debug)
     case "trace" => Some(LogLevel.Trace)
-    case _       => None
+    case "loglevel.error" => Some(LogLevel.Error)
+    case "loglevel.warn" => Some(LogLevel.Warn)
+    case "loglevel.info" => Some(LogLevel.Info)
+    case "loglevel.debug" => Some(LogLevel.Debug)
+    case "loglevel.trace" => Some(LogLevel.Trace)
+    case _ => None
   }
 
   implicit val logLevelShow: Show[LogLevel] = Show.show[LogLevel] {


### PR DESCRIPTION
I have this in my codebase, figured it makes sense to push upstream.

Do we want it to match the output of `show` at all?