### PR TITLE
Prepare release 2.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,22 +123,22 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.0.0-RC2)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-3.0.0-RC2-${{ matrix.java }}
-
-      - name: Inflate target directories (3.0.0-RC2)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
       - name: Download target directories (3.0.0-RC1)
         uses: actions/download-artifact@v2
         with:
           name: target-${{ matrix.os }}-3.0.0-RC1-${{ matrix.java }}
 
       - name: Inflate target directories (3.0.0-RC1)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.0.0-RC2)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.0.0-RC2-${{ matrix.java }}
+
+      - name: Inflate target directories (3.0.0-RC2)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.5, 2.12.13, 3.0.0-M3, 3.0.0-RC1]
+        scala: [2.13.5, 2.12.13, 3.0.0-RC1, 3.0.0-RC2]
         java: [adopt@1.8, adopt@1.11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -123,12 +123,12 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.0.0-M3)
+      - name: Download target directories (3.0.0-RC2)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-3.0.0-M3-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.0.0-RC2-${{ matrix.java }}
 
-      - name: Inflate target directories (3.0.0-M3)
+      - name: Inflate target directories (3.0.0-RC2)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 This file summarizes **notable** changes for each release, but does not describe internal changes unless they are particularly exciting.
 
 ----
+# <a name="2.0.1"></a>New and Noteworthy for Version 2.0.1
+
+- cats-effect 3.0.1
+- add Scala 3.0.0-RC2 build
+- drop Scala 3.0.0-M3 build
+
+# <a name="2.0.0"></a>New and Noteworthy for Version 2.0.0
+
+### Breaking changes
+- #410: remove unused constraints. This is binary-breaking, but not user facing.
+
+Dependency upgrades:
+- cats-effect 3.0.0
+
 # <a name="2.0.0-RC1"></a>New and Noteworthy for Version 2.0.0-RC1
 
 - removed deprecated `org.typelevel.log4cats.extras.Translate` object
@@ -22,17 +36,27 @@ Forward ports from `1.2.0`:
 
 - Depends on cats-effect-3.0.0-M5
 
-# <a name="1.2.0-RC3"></a>New and Noteworthy for Version 1.2.0-RC3
+# <a name="1.2.2"></a>New and Noteworthy for Version 1.2.2
+- cats-effect-2.4.1
+- cats 2.5.0
+- add Scala 3.0.0-RC2 build
+- drop Scala 3.0.0-M3 build
 
-- add `LogLevel.fromString` method [#343](https://github.com/typelevel/log4cats/pull/343) thanks to [@Daenyth](https://github.com/Daenyth)
-- add `NoOpLogger.apply` constructor [#344](https://github.com/typelevel/log4cats/pull/344) thanks to [@bplommer](https://github.com/bplommer)
-- add `StructuredLogger.withModifiedContext`method [#361](https://github.com/typelevel/log4cats/pull/361) thanks to [@ivan-klass](https://github.com/ivan-klass)
-- depends on cats-2.4.2 and cats-effect-2.3.2
-- built with Scala.js 1.5.0
-- adds Dotty crossbuild for Scala 3.0.0-RC1
-- drops Dotty crossbuild for Scala 3.0.0-M2
+# <a name="1.2.1"></a>New and Noteworthy for Version 1.2.1
+- cats-effect-2.4.0
 
-# <a name="1.2.0-RC2"></a>New and Noteworthy for Version 1.2.0-RC1
+# <a name="1.2.0"></a>New and Noteworthy for Version 1.2.0
+
+- add LogLevel.fromString method #343 thanks to @Daenyth
+- add NoOpLogger.apply constructor #344 thanks to @bplommer
+- add StructuredLogger.withModifiedContextmethod #361 thanks to @ivan-klass
+- add Scala 3.0.0-RC1 build
+- drop Scala 3.0.0-M2 build
+- cats-2.4.2
+- cats-effect-2.3.3
+- scalajs-1.5.0
+
+# <a name="1.2.0-RC1"></a>New and Noteworthy for Version 1.2.0-RC1
 
 - Now published under `org.typelevel`
 - Root package changed to `org.typelevel.log4cats`

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ enablePlugins(SonatypeCiReleasePlugin)
 
 ThisBuild / organization := "org.typelevel"
 ThisBuild / baseVersion := "2.0"
-ThisBuild / crossScalaVersions := Seq(Scala213, Scala212, "3.0.0-M3", "3.0.0-RC1")
+ThisBuild / crossScalaVersions := Seq(Scala213, Scala212, "3.0.0-RC1", "3.0.0-RC2")
 ThisBuild / scalaVersion := Scala213
 ThisBuild / publishFullName := "Christopher Davenport"
 ThisBuild / publishGithubUser := "christopherdavenport"
@@ -21,6 +21,7 @@ ThisBuild / versionIntroduced := Map(
   "2.13" -> "1.2.0",
   "3.0.0-M3" -> "1.2.0",
   "3.0.0-RC1" -> "1.2.0",
+  "3.0.0-RC2" -> "1.2.2"
 )
 
 val MicrositesCond = s"matrix.scala == '$Scala212'"
@@ -73,10 +74,10 @@ ThisBuild / githubWorkflowPublish := Seq(
   cond = Some(MicrositesCond)
 )
 
-val catsV = "2.4.2"
-val catsEffectV = "3.0.0"
+val catsV = "2.5.0"
+val catsEffectV = "3.0.1"
 val slf4jV = "1.7.30"
-val munitCatsEffectV = "1.0.0"
+val munitCatsEffectV = "1.0.1"
 val logbackClassicV = "1.2.3"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
 sbt.version=1.4.9
-


### PR DESCRIPTION
I think this is everything we need to get 2.0.1 w/ Scala 3.0.0-RC2 out the door.

Created by merging #418 into this one.

So if something's wrong with that PR, then we should drop this one and retry :sweat_smile: 