### PR TITLE
Add missing `withModifiedString` overrides in `Logger[F]` subclasses

### DIFF
--- a/core/shared/src/main/scala/org/typelevel/log4cats/SelfAwareStructuredLogger.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/SelfAwareStructuredLogger.scala
@@ -21,6 +21,9 @@ import cats._
 trait SelfAwareStructuredLogger[F[_]] extends SelfAwareLogger[F] with StructuredLogger[F] {
   override def mapK[G[_]](fk: F ~> G): SelfAwareStructuredLogger[G] =
     SelfAwareStructuredLogger.mapK(fk)(this)
+
+  override def withModifiedString(f: String => String): SelfAwareStructuredLogger[F] =
+    SelfAwareStructuredLogger.withModifiedString[F](this, f)
 }
 
 object SelfAwareStructuredLogger {
@@ -79,6 +82,44 @@ object SelfAwareStructuredLogger {
     def trace(ctx: Map[String, String], t: Throwable)(message: => String): F[Unit] =
       sl.trace(modify(ctx), t)(message)
   }
+
+  private def withModifiedString[F[_]](
+      l: SelfAwareStructuredLogger[F],
+      f: String => String
+  ): SelfAwareStructuredLogger[F] =
+    new SelfAwareStructuredLogger[F] {
+      def isTraceEnabled: F[Boolean] = l.isTraceEnabled
+      def isDebugEnabled: F[Boolean] = l.isDebugEnabled
+      def isInfoEnabled: F[Boolean] = l.isInfoEnabled
+      def isWarnEnabled: F[Boolean] = l.isWarnEnabled
+      def isErrorEnabled: F[Boolean] = l.isErrorEnabled
+
+      override def trace(ctx: Map[String, String])(msg: => String): F[Unit] = l.trace(ctx)(f(msg))
+      override def trace(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+        l.trace(ctx, t)(f(msg))
+      override def debug(ctx: Map[String, String])(msg: => String): F[Unit] = l.debug(ctx)(f(msg))
+      override def debug(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+        l.debug(ctx, t)(f(msg))
+      override def info(ctx: Map[String, String])(msg: => String): F[Unit] = l.info(ctx)(f(msg))
+      override def info(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+        l.info(ctx, t)(f(msg))
+      override def warn(ctx: Map[String, String])(msg: => String): F[Unit] = l.warn(ctx)(f(msg))
+      override def warn(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+        l.warn(ctx, t)(f(msg))
+      override def error(ctx: Map[String, String])(msg: => String): F[Unit] = l.error(ctx)(f(msg))
+      override def error(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+        l.error(ctx, t)(f(msg))
+      override def error(message: => String): F[Unit] = l.error(f(message))
+      override def error(t: Throwable)(message: => String): F[Unit] = l.error(t)(f(message))
+      override def warn(message: => String): F[Unit] = l.warn(f(message))
+      override def warn(t: Throwable)(message: => String): F[Unit] = l.warn(t)(f(message))
+      override def info(message: => String): F[Unit] = l.info(f(message))
+      override def info(t: Throwable)(message: => String): F[Unit] = l.info(t)(f(message))
+      override def debug(message: => String): F[Unit] = l.debug(f(message))
+      override def debug(t: Throwable)(message: => String): F[Unit] = l.debug(t)(f(message))
+      override def trace(message: => String): F[Unit] = l.trace(f(message))
+      override def trace(t: Throwable)(message: => String): F[Unit] = l.trace(t)(f(message))
+    }
 
   private def mapK[G[_], F[_]](
       f: G ~> F

--- a/core/shared/src/test/scala/org/typelevel/log4cats/extras/syntax/LoggerSyntaxCompilation.scala
+++ b/core/shared/src/test/scala/org/typelevel/log4cats/extras/syntax/LoggerSyntaxCompilation.scala
@@ -39,4 +39,17 @@ object LoggerSyntaxCompilation {
   def selfAwareStructuredLoggerMapK[F[_], G[_]](l: SelfAwareStructuredLogger[F])(f: F ~> G) =
     l.mapK(f)
 
+  def loggerSyntaxWithModifiedString[F[_]](l: Logger[F]): Logger[F] = l.withModifiedString(identity)
+
+  def selfAwareLoggerSyntaxWithModifiedString[F[_]](l: SelfAwareLogger[F]): SelfAwareLogger[F] =
+    l.withModifiedString(identity)
+
+  def structuredLoggerSyntaxWithModifiedString[F[_]](l: StructuredLogger[F]): StructuredLogger[F] =
+    l.withModifiedString(identity)
+
+  def selfAwareStructuredLoggerSyntaxWithModifiedString[F[_]](
+      l: SelfAwareStructuredLogger[F]
+  ): SelfAwareStructuredLogger[F] =
+    l.withModifiedString(identity)
+
 }


### PR DESCRIPTION
`Logger[F]` defined the method ` def withModifiedString(f: String => String): Logger[F]`

But subclasses of `Logger[F]` did not override it, leading to inconsistencies that are irksome at best:

```scala
val logger: SelfAwareStructuredLogger[IO] = ???
// does not compile because the method would return only Logger[IO]
val specialLogger: SelfAwareStructuredLogger[IO] = logger.withModifiedString(identity)
```
Now it's fixed.