### PR TITLE
Add syntax for the `Logger`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,25 @@ object MyThing {
   } yield something
 }
 ```
+
+### Laconic syntax
+
+It's possible to use interpolated syntax for logging.
+Currently, supported ops are: `trace`, `debug`, `info`, `warn`, `error`.
+You can use it for your custom `Logger` as well as for Slf4j `Logger`.
+
+```scala mdoc
+import cats.effect.Sync
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.syntax._
+
+def successComputation[F[_]: Sync]: F[Int] = Sync[F].pure(1)
+def errorComputation[F[_]: Sync]: F[Unit] = Sync[F].raiseError[Unit](new Throwable("Sorry!"))
+
+def log[F[_]: Sync: Logger] = 
+  for {
+    result1 <- successComputation[F]
+    _ <- info"First result is $result1"
+    _ <- errorComputation[F].onError(_ => error"We got an error!")
+  } yield ()
+```

--- a/README.md
+++ b/README.md
@@ -62,12 +62,13 @@ It's possible to use interpolated syntax for logging.
 Currently, supported ops are: `trace`, `debug`, `info`, `warn`, `error`.
 You can use it for your custom `Logger` as well as for Slf4j `Logger`.
 
-```scala mdoc
+```scala
+import cats.Applicative
 import cats.effect.Sync
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.syntax._
 
-def successComputation[F[_]: Sync]: F[Int] = Sync[F].pure(1)
+def successComputation[F[_]: Applicative]: F[Int] = Applicative[F].pure(1)
 def errorComputation[F[_]: Sync]: F[Unit] = Sync[F].raiseError[Unit](new Throwable("Sorry!"))
 
 def log[F[_]: Sync: Logger] = 

--- a/core/shared/src/main/scala/org/typelevel/log4cats/syntax/package.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/syntax/package.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Christopher Davenport
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.log4cats
+
+package object syntax {
+  implicit final class LoggerInterpolator(private val sc: StringContext) extends AnyVal {
+    def error[F[_]](message: Any*)(implicit logger: Logger[F]): F[Unit] =
+      logger.error(sc.s(message: _*))
+
+    def warn[F[_]](message: Any*)(implicit logger: Logger[F]): F[Unit] =
+      logger.warn(sc.s(message: _*))
+
+    def info[F[_]](message: Any*)(implicit logger: Logger[F]): F[Unit] =
+      logger.info(sc.s(message: _*))
+
+    def debug[F[_]](message: Any*)(implicit logger: Logger[F]): F[Unit] =
+      logger.debug(sc.s(message: _*))
+
+    def trace[F[_]](message: Any*)(implicit logger: Logger[F]): F[Unit] =
+      logger.trace(sc.s(message: _*))
+  }
+}

--- a/docs/src/main/mdoc/index.md
+++ b/docs/src/main/mdoc/index.md
@@ -59,3 +59,24 @@ def passForEasierUse[F[_]: Sync: Logger] = for {
     _ <- Logger[F].info("Logging at end of passForEasierUse")
   } yield something
 ```
+
+### Laconic syntax
+It's possible to use interpolated syntax for logging. 
+Currently, supported ops are: `trace`, `debug`, `info`, `warn`, `error`.
+You can use it for your custom `Logger` as well as for Slf4j `Logger`.
+
+```scala mdoc
+import cats.effect.Sync
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.syntax._
+
+def successComputation[F[_]: Sync]: F[Int] = Sync[F].pure(1)
+def errorComputation[F[_]: Sync]: F[Unit] = Sync[F].raiseError[Unit](new Throwable("Sorry!"))
+
+def log[F[_]: Sync: Logger] = 
+  for {
+    result1 <- successComputation[F]
+    _ <- info"First result is $result1"
+    _ <- errorComputation[F].onError(_ => error"We got an error!")
+  } yield ()
+```

--- a/docs/src/main/mdoc/index.md
+++ b/docs/src/main/mdoc/index.md
@@ -67,17 +67,20 @@ Currently, supported ops are: `trace`, `debug`, `info`, `warn`, `error`.
 You can use it for your custom `Logger` as well as for Slf4j `Logger`.
 
 ```scala mdoc
+import cats.Applicative
 import cats.effect.Sync
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.syntax._
 
-def successComputation[F[_]: Sync]: F[Int] = Sync[F].pure(1)
+def successComputation[F[_]: Applicative]: F[Int] = Applicative[F].pure(1)
 def errorComputation[F[_]: Sync]: F[Unit] = Sync[F].raiseError[Unit](new Throwable("Sorry!"))
 
 def log[F[_]: Sync: Logger] = 
   for {
     result1 <- successComputation[F]
     _ <- info"First result is $result1"
-    _ <- errorComputation[F].onError(_ => error"We got an error!")
+    _ <- errorComputation[F].onError {
+      case _ => error"We got an error!"
+    }
   } yield ()
 ```

--- a/docs/src/main/mdoc/index.md
+++ b/docs/src/main/mdoc/index.md
@@ -61,6 +61,7 @@ def passForEasierUse[F[_]: Sync: Logger] = for {
 ```
 
 ### Laconic syntax
+
 It's possible to use interpolated syntax for logging. 
 Currently, supported ops are: `trace`, `debug`, `info`, `warn`, `error`.
 You can use it for your custom `Logger` as well as for Slf4j `Logger`.

--- a/docs/src/main/mdoc/index.md
+++ b/docs/src/main/mdoc/index.md
@@ -27,7 +27,7 @@ libraryDependencies ++= Seq(
 ```scala mdoc
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-import cats.effect.{Sync, IO}
+import cats.effect.Sync
 import cats.implicits._
 
 object MyThing {


### PR DESCRIPTION
This adds syntax that allows logging in that way:
```scala
def log[F[_]: Sync: Logger] = 
  for {
    result1 <- successComputation[F]
    _ <- info"First result is $result1"
    _ <- errorComputation[F].onError(_ => error"We got an error!")
  } yield ()
 ```