### PR TITLE
Fixes for log4cats-1.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,49 @@ jobs:
       - name: Scalafmt
         run: sbt ++${{ matrix.scala }} scalafmtCheckAll
 
+  headers:
+    name: Headers
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.8, 2.12.15, 3.0.2]
+        java: [temurin@11]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Setup Java (temurin@11)
+        if: matrix.java == 'temurin@11'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Cache sbt
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+            ~/AppData/Local/Coursier/Cache/v1
+            ~/Library/Caches/Coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Headers
+        run: sbt ++${{ matrix.scala }} headerCheckAll
+
   microsite:
     name: Microsite
     strategy:

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ enablePlugins(SonatypeCiReleasePlugin)
 
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"
-ThisBuild / baseVersion := "1.3"
+ThisBuild / baseVersion := "1.5"
 ThisBuild / crossScalaVersions := Seq(Scala213, Scala212, Scala3)
 ThisBuild / scalaVersion := Scala213
 ThisBuild / publishFullName := "Christopher Davenport"

--- a/build.sbt
+++ b/build.sbt
@@ -163,7 +163,10 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "org.typelevel" %%% "munit-cats-effect-2" % munitCatsEffectV % Test
   ),
-  testFrameworks += new TestFramework("munit.Framework")
+  testFrameworks += new TestFramework("munit.Framework"),
+  mimaPreviousArtifacts ~= { xs =>
+    xs.filterNot(_.revision == "1.5.0") // cursed tag
+  }
 )
 
 lazy val releaseSettings = {

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,14 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
     scalas = crossScalaVersions.value.toList.filter(_.startsWith("2."))
   ),
   WorkflowJob(
+    "headers",
+    "Headers",
+    githubWorkflowJobSetup.value.toList ::: List(
+      WorkflowStep.Sbt(List("headerCheckAll"), name = Some("Headers"))
+    ),
+    scalas = crossScalaVersions.value.toList
+  ),
+  WorkflowJob(
     "microsite",
     "Microsite",
     githubWorkflowJobSetup.value.toList ::: (micrositeWorkflowSteps(None) :+ WorkflowStep

--- a/core/shared/src/main/scala/org/typelevel/log4cats/syntax/package.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/syntax/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Christopher Davenport
+ * Copyright 2018 Typelevel
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The build was creating headers, but not checking headers.  This resulted in a diff, which bumped the version past the tag and resulted in a resolution failure on MiMa.  Cool.

I took a conservative approach and did not port to sbt-typelevel.