### PR TITLE
Add artifact updates ignoring for Scala Steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -3,3 +3,15 @@ updates.pin = [
   { groupId = "org.scala-lang", artifactId = "scala-library", version = "3.0." },
   { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = "3.0." },
 ]
+
+updates.ignore = [
+  # These will be merged forward from series/1.x
+  { groupId = "org.typelevel", artifactId = "sbt-typelevel" },
+  { groupId = "org.typelevel", artifactId = "sbt-typelevel-site" },
+  { groupId = "org.typelevel", artifactId = "cats-core" },
+  { groupId = "org.slf4j", artifactId = "slf4j-api" },
+  { groupId = "ch.qos.logback", artifactId = "logback-classic" },
+  { groupId = "pl.project13.scala", artifactId = "sbt-jmh" },
+  { groupId = "org.scala-sbt" },
+  { groupId = "org.scalameta", artifactId = "scalafmt-core" }
+]


### PR DESCRIPTION
Updates of these artifacts will come from `series/1.x`.