### PR TITLE
Ignore ScalaJS updates

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -13,5 +13,6 @@ updates.ignore = [
   { groupId = "ch.qos.logback", artifactId = "logback-classic" },
   { groupId = "pl.project13.scala", artifactId = "sbt-jmh" },
   { groupId = "org.scala-sbt" },
-  { groupId = "org.scalameta", artifactId = "scalafmt-core" }
+  { groupId = "org.scalameta", artifactId = "scalafmt-core" },
+  { groupId = "org.scala-js" }
 ]


### PR DESCRIPTION
At the moment, log4cats has the same version of ScalaJS for both supported branches. I think this will continue, so here is this PR. log4cats will get updates of ScalaJS from `series/1.x`.