### PR TITLE
Add `LoggerFactory` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Alternatively, a mutually exclusive solution is to explicitly create your
 `LoggerFactory[F]` instance and pass them around implicitly:
 ```scala
 import cats.effect.IO
+import cats.Monad
+import cats.syntax.all._
 import org.typelevel.log4cats._
 import org.typelevel.log4cats.slf4j.Slf4jFactory
 
@@ -122,9 +124,16 @@ implicit val logging: LoggerFactory[IO] = Slf4jFactory[IO]
 val logger: SelfAwareStructuredLogger[IO] = LoggerFactory[IO].getLogger
 logger.info("logging in IO!"): IO[Unit]
 
-def useLogging[F[_]: LoggerFactory] = 
-  LoggerFactory[F].getLogger.info("yay! effect polymorphic code")
-useLogging[IO]
+// basic example of a service using LoggerFactory
+class LoggerUsingService[F[_]: LoggerFactory: Monad] {
+  val logger = LoggerFactory[F].getLogger
+  def use(args: String): F[Unit] =
+    for {
+      _ <- logger.info("yay! effect polymorphic code")
+      _ <- logger.debug(s"and $args")
+    } yield ()
+}
+new LoggerUsingService[IO].use("foo")
 ```
 
 ## CVE-2021-44228 ("log4shell")

--- a/README.md
+++ b/README.md
@@ -82,18 +82,18 @@ def log[F[_]: Sync: Logger] =
 ## Logging using capabilities
 
 You can work with logging using capabilities. It's implemented via the `LoggerFactory` trait.
-You instantiate it once in your application (dependent on the specific logging backend you use)
+You instantiate it once (dependent on the specific logging backend you use)
 and pass this around in your application.
 
 This brings several advantages:
 
-* it's no more need to pass everywhere the very powerful `F[_]: Sync` constraint
+* it's no more needed to pass the very powerful `F[_]: Sync` constraint everywhere 
   that can do almost anything when you only need logging.
 * you have control of loggers creation, and you can even add in whatever custom
   functionality you need for your applications here. E.g. create loggers that also push logs
   to some external providers by giving a custom implementation of this trait.
 
-If you are unsure how to create a `LoggerFactory[F]`, then you can to look at the `log4cats-slf4j`,
+If you are unsure how to create a new `LoggerFactory[F]` instance, then you can look at the `log4cats-slf4j`,
 or `log4cats-noop` modules for concrete implementations.
 
 The quickest fix might be to import needed implicits:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,54 @@ def log[F[_]: Sync: Logger] =
   } yield ()
 ```
 
+## Logging using capabilities
+
+You can work with logging using capabilities. It's implemented via the `LoggerFactory` trait.
+You instantiate it once in your application (dependent on the specific logging backend you use)
+and pass this around in your application.
+
+This brings several advantages:
+
+* it's no more need to pass everywhere the very powerful `F[_]: Sync` constraint
+  that can do almost anything when you only need logging.
+* you have control of loggers creation, and you can even add in whatever custom
+  functionality you need for your applications here. E.g. create loggers that also push logs
+  to some external providers by giving a custom implementation of this trait.
+
+If you are unsure how to create a `LoggerFactory[F]`, then you can to look at the `log4cats-slf4j`,
+or `log4cats-noop` modules for concrete implementations.
+
+The quickest fix might be to import needed implicits:
+```scala
+// assumes dependency on log4cats-slf4j module
+import org.typelevel.log4cats._
+import org.typelevel.log4cats.slf4j._
+
+val logger: SelfAwareStructuredLogger[IO] = LoggerFactory[IO].getLogger
+
+// or
+def anyFSyncLogger[F[_]: Sync]: SelfAwareStructuredLogger[F] = Slf4jFactory[F].getLogger
+```
+
+Alternatively, a mutually exclusive solution is to explicitly create your
+`LoggerFactory[F]` instance and pass them around implicitly:
+```scala
+import cats.effect.IO
+import org.typelevel.log4cats._
+import org.typelevel.log4cats.slf4j.Slf4jFactory
+
+// create our LoggerFactory
+implicit val logging: LoggerFactory[IO] = Slf4jFactory[IO]
+
+// we summon LoggerFactory instance, and create logger
+val logger: SelfAwareStructuredLogger[IO] = LoggerFactory[IO].getLogger
+logger.info("logging in IO!"): IO[Unit]
+
+def useLogging[F[_]: LoggerFactory] = 
+  LoggerFactory[F].getLogger.info("yay! effect polymorphic code")
+useLogging[IO]
+```
+
 ## CVE-2021-44228 ("log4shell")
 
 log4cats is not directly susceptible to CVS-2021-44228.  The

--- a/core/shared/src/main/scala/org/typelevel/log4cats/LoggerFactory.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/LoggerFactory.scala
@@ -20,7 +20,7 @@ import scala.annotation.implicitNotFound
 
 @implicitNotFound("""
 Implicit not found for LoggerFactory[${F}].
-Information can be found here: https://log4cats.github.io/logging-capability.html
+Learn about LoggerFactory at https://typelevel.org/log4cats/#logging-using-capabilities
 """)
 trait LoggerFactory[F[_]] extends LoggerFactoryGen[F] {
   type LoggerType = SelfAwareStructuredLogger[F]

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,6 +116,8 @@ Alternatively, a mutually exclusive solution is to explicitly create your
 `LoggerFactory[F]` instance and pass them around implicitly:
 ```scala mdoc:reset:silent
 import cats.effect.IO
+import cats.Monad
+import cats.syntax.all._
 import org.typelevel.log4cats._
 import org.typelevel.log4cats.slf4j.Slf4jFactory
 
@@ -126,9 +128,16 @@ implicit val logging: LoggerFactory[IO] = Slf4jFactory[IO]
 val logger: SelfAwareStructuredLogger[IO] = LoggerFactory[IO].getLogger
 logger.info("logging in IO!"): IO[Unit]
 
-def useLogging[F[_]: LoggerFactory] = 
-  LoggerFactory[F].getLogger.info("yay! effect polymorphic code")
-useLogging[IO]
+// basic example of a service using LoggerFactory
+class LoggerUsingService[F[_]: LoggerFactory: Monad] {
+  val logger = LoggerFactory[F].getLogger
+  def use(args: String): F[Unit] = 
+    for {
+      _ <- logger.info("yay! effect polymorphic code")
+      _ <- logger.debug(s"and $args")
+    } yield ()
+}
+new LoggerUsingService[IO].use("foo")
 ```
 
 ## CVE-2021-44228 ("log4shell")

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,6 +83,54 @@ def log[F[_]: Sync: Logger] =
   } yield ()
 ```
 
+## Logging using capabilities
+
+You can work with logging using capabilities. It's implemented via the `LoggerFactory` trait. 
+You instantiate it once in your application (dependent on the specific logging backend you use) 
+and pass this around in your application.
+
+This brings several advantages:
+
+* it's no more need to pass everywhere the very powerful `F[_]: Sync` constraint 
+  that can do almost anything when you only need logging.
+* you have control of loggers creation, and you can even add in whatever custom 
+  functionality you need for your applications here. E.g. create loggers that also push logs 
+  to some external providers by giving a custom implementation of this trait.
+
+If you are unsure how to create a `LoggerFactory[F]`, then you can to look at the `log4cats-slf4j`, 
+or `log4cats-noop` modules for concrete implementations.
+
+The quickest fix might be to import needed implicits:
+```scala mdoc:silent
+// assumes dependency on log4cats-slf4j module
+import org.typelevel.log4cats._
+import org.typelevel.log4cats.slf4j._
+
+val logger: SelfAwareStructuredLogger[IO] = LoggerFactory[IO].getLogger
+
+// or
+def anyFSyncLogger[F[_]: Sync]: SelfAwareStructuredLogger[F] = Slf4jFactory[F].getLogger
+```
+
+Alternatively, a mutually exclusive solution is to explicitly create your 
+`LoggerFactory[F]` instance and pass them around implicitly:
+```scala mdoc:reset:silent
+import cats.effect.IO
+import org.typelevel.log4cats._
+import org.typelevel.log4cats.slf4j.Slf4jFactory
+
+// create our LoggerFactory
+implicit val logging: LoggerFactory[IO] = Slf4jFactory[IO]
+
+// we summon LoggerFactory instance, and create logger
+val logger: SelfAwareStructuredLogger[IO] = LoggerFactory[IO].getLogger
+logger.info("logging in IO!"): IO[Unit]
+
+def useLogging[F[_]: LoggerFactory] = 
+  LoggerFactory[F].getLogger.info("yay! effect polymorphic code")
+useLogging[IO]
+```
+
 ## CVE-2021-44228 ("log4shell")
 
 log4cats is not directly susceptible to CVS-2021-44228.  The

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,18 +86,18 @@ def log[F[_]: Sync: Logger] =
 ## Logging using capabilities
 
 You can work with logging using capabilities. It's implemented via the `LoggerFactory` trait. 
-You instantiate it once in your application (dependent on the specific logging backend you use) 
+You instantiate it once (dependent on the specific logging backend you use) 
 and pass this around in your application.
 
 This brings several advantages:
 
-* it's no more need to pass everywhere the very powerful `F[_]: Sync` constraint 
+* it's no more needed to pass the very powerful `F[_]: Sync` constraint everywhere 
   that can do almost anything when you only need logging.
 * you have control of loggers creation, and you can even add in whatever custom 
   functionality you need for your applications here. E.g. create loggers that also push logs 
   to some external providers by giving a custom implementation of this trait.
 
-If you are unsure how to create a `LoggerFactory[F]`, then you can to look at the `log4cats-slf4j`, 
+If you are unsure how to create a new `LoggerFactory[F]` instance, then you can look at the `log4cats-slf4j`,
 or `log4cats-noop` modules for concrete implementations.
 
 The quickest fix might be to import needed implicits:


### PR DESCRIPTION
These docs are based on work made by @lorandszakacs in https://github.com/typelevel/log4cats/pull/421. So all credits go to them.
This covers a little part of the `LoggerFactory`, a basic functionality at most. It'd be great to complete it subsequently.