### PR TITLE
Merge 1.6.0

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -3,16 +3,3 @@ updates.pin = [
   { groupId = "org.scala-lang", artifactId = "scala-library", version = "3.0." },
   { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1", version = "3.0." },
 ]
-
-updates.ignore = [
-  # These will be merged forward from series/1.x
-  { groupId = "org.typelevel", artifactId = "sbt-typelevel" },
-  { groupId = "org.typelevel", artifactId = "sbt-typelevel-site" },
-  { groupId = "org.typelevel", artifactId = "cats-core" },
-  { groupId = "org.slf4j", artifactId = "slf4j-api" },
-  { groupId = "ch.qos.logback", artifactId = "logback-classic" },
-  { groupId = "pl.project13.scala", artifactId = "sbt-jmh" },
-  { groupId = "org.scala-sbt" },
-  { groupId = "org.scalameta", artifactId = "scalafmt-core" },
-  { groupId = "org.scala-js" }
-]


### PR DESCRIPTION
Hopefully the last from this branch.

I rolled back scalafmt-3.5.3, which wasn't on main yet, and has caused problems on other projects.

I also removed updates.ignore, as the 1.x branch will be removed from Scala Steward.