### PR TITLE
Add LoggerFactory.mapK

### DIFF
--- a/core/shared/src/main/scala/org/typelevel/log4cats/LoggerFactory.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/LoggerFactory.scala
@@ -33,17 +33,16 @@ trait LoggerFactory[F[_]] extends LoggerFactoryGen[F] {
 object LoggerFactory extends LoggerFactoryGenCompanion {
   def apply[F[_]: LoggerFactory]: LoggerFactory[F] = implicitly
 
-  def mapK[F[_]: Functor, G[_]](fk: F ~> G)(lfg: LoggerFactory[F]): LoggerFactory[G] =
+  def mapK[F[_]: Functor, G[_]](fk: F ~> G)(lf: LoggerFactory[F]): LoggerFactory[G] =
     new LoggerFactory[G] {
 
-      def getLoggerFromName(name: String): LoggerType = lfg
+      def getLoggerFromName(name: String): LoggerType = lf
         .getLoggerFromName(name)
         .mapK(fk)
 
       def fromName(name: String): G[LoggerType] = {
-        val loggerG = lfg.fromName(name).map(_.mapK(fk))
-        fk(loggerG)
+        val logger = lf.fromName(name).map(_.mapK(fk))
+        fk(logger)
       }
-
     }
 }

--- a/core/shared/src/main/scala/org/typelevel/log4cats/LoggerFactory.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/LoggerFactory.scala
@@ -28,12 +28,15 @@ Learn about LoggerFactory at https://typelevel.org/log4cats/#logging-using-capab
 """)
 trait LoggerFactory[F[_]] extends LoggerFactoryGen[F] {
   type LoggerType = SelfAwareStructuredLogger[F]
+
+  def mapK[G[_]](fk: F ~> G)(implicit F: Functor[F]): LoggerFactory[G] =
+    LoggerFactory.mapK[F, G](fk)(this)
 }
 
 object LoggerFactory extends LoggerFactoryGenCompanion {
   def apply[F[_]: LoggerFactory]: LoggerFactory[F] = implicitly
 
-  def mapK[F[_]: Functor, G[_]](fk: F ~> G)(lf: LoggerFactory[F]): LoggerFactory[G] =
+  private def mapK[F[_]: Functor, G[_]](fk: F ~> G)(lf: LoggerFactory[F]): LoggerFactory[G] =
     new LoggerFactory[G] {
 
       def getLoggerFromName(name: String): LoggerType = lf

--- a/core/shared/src/test/scala/org/typelevel/log4cats/extras/syntax/LoggerFactorySyntaxCompilation.scala
+++ b/core/shared/src/test/scala/org/typelevel/log4cats/extras/syntax/LoggerFactorySyntaxCompilation.scala
@@ -1,0 +1,17 @@
+package org.typelevel.log4cats.extras.syntax
+
+import cats._
+import cats.data.Kleisli
+import org.typelevel.log4cats.LoggerFactory
+
+object LoggerFactorySyntaxCompilation {
+  def loggerFactorySyntaxMapK[F[_]: Functor, G[_]](lf: LoggerFactory[F])(
+      fk: F ~> G
+  ): LoggerFactory[G] =
+    lf.mapK[G](fk)
+
+  def loggerFactoryKleisliLiftK[F[_]: Functor, A](
+      lf: LoggerFactory[F]
+  ): LoggerFactory[Kleisli[F, A, *]] =
+    lf.mapK(Kleisli.liftK[F, A])
+}

--- a/core/shared/src/test/scala/org/typelevel/log4cats/extras/syntax/LoggerFactorySyntaxCompilation.scala
+++ b/core/shared/src/test/scala/org/typelevel/log4cats/extras/syntax/LoggerFactorySyntaxCompilation.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.typelevel.log4cats.extras.syntax
 
 import cats._


### PR DESCRIPTION
I've been playing around with Natchez and natchez-extras-log4cats. This proved to be a required step to use LoggerFactory rather than instantiating a Kleisli logger and passing around explicitly/implicitly.

I would have applied this to LoggerFactoryGen but with the override type I struggled, I think you would need to lift it into the typeclass signature, but suggestions welcome. 