### PR TITLE
Base version is 2.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val Scala213 = "2.13.8"
 val Scala212 = "2.12.16"
 val Scala3 = "3.0.2"
 
-ThisBuild / tlBaseVersion := "2.3"
+ThisBuild / tlBaseVersion := "2.4"
 ThisBuild / crossScalaVersions := Seq(Scala213, Scala212, Scala3)
 ThisBuild / scalaVersion := Scala213
 ThisBuild / startYear := Some(2018)


### PR DESCRIPTION
At least because of the Scala 3 upgrade in #664.  Probably other reasons.