### PR TITLE
Helpers for creating simple/stub versions of `SelfAwareStructuredLogger` and `LoggerFactory`

### DIFF
--- a/core/shared/src/main/scala/org/typelevel/log4cats/ErrorLogger.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/ErrorLogger.scala
@@ -28,6 +28,14 @@ trait ErrorLogger[F[_]] {
 }
 
 object ErrorLogger {
+  trait Fallback[F[_]] extends ErrorLogger[F] { _: MessageLogger[F] =>
+    final def error(t: Throwable)(message: => String): F[Unit] = error(message)
+    final def warn(t: Throwable)(message: => String): F[Unit] = warn(message)
+    final def info(t: Throwable)(message: => String): F[Unit] = info(message)
+    final def debug(t: Throwable)(message: => String): F[Unit] = debug(message)
+    final def trace(t: Throwable)(message: => String): F[Unit] = trace(message)
+  }
+
   def apply[F[_]](implicit ev: ErrorLogger[F]): ErrorLogger[F] = ev
 
   private def mapK[G[_], F[_]](f: G ~> F)(logger: ErrorLogger[G]): ErrorLogger[F] =

--- a/core/shared/src/main/scala/org/typelevel/log4cats/SelfAwareLogger.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/SelfAwareLogger.scala
@@ -32,6 +32,15 @@ trait SelfAwareLogger[F[_]] extends Logger[F] {
 object SelfAwareLogger {
   def apply[F[_]](implicit ev: SelfAwareLogger[F]): SelfAwareLogger[F] = ev
 
+  trait Stubbed[F[_]] extends SelfAwareLogger[F] {
+    protected def F: Applicative[F]
+    def isTraceEnabled: F[Boolean] = F.pure(true)
+    def isDebugEnabled: F[Boolean] = F.pure(true)
+    def isInfoEnabled: F[Boolean] = F.pure(true)
+    def isWarnEnabled: F[Boolean] = F.pure(true)
+    def isErrorEnabled: F[Boolean] = F.pure(true)
+  }
+
   private def mapK[G[_], F[_]](f: G ~> F)(logger: SelfAwareLogger[G]): SelfAwareLogger[F] =
     new SelfAwareLogger[F] {
       def isTraceEnabled: F[Boolean] =

--- a/core/shared/src/main/scala/org/typelevel/log4cats/StructuredLogger.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/StructuredLogger.scala
@@ -48,6 +48,19 @@ trait StructuredLogger[F[_]] extends Logger[F] {
 }
 
 object StructuredLogger {
+  trait Fallback[F[_]] extends StructuredLogger[F] {
+    def trace(ctx: Map[String, String])(msg: => String): F[Unit] = trace(msg)
+    def trace(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] = trace(t)(msg)
+    def debug(ctx: Map[String, String])(msg: => String): F[Unit] = debug(msg)
+    def debug(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] = debug(t)(msg)
+    def info(ctx: Map[String, String])(msg: => String): F[Unit] = info(msg)
+    def info(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] = info(t)(msg)
+    def warn(ctx: Map[String, String])(msg: => String): F[Unit] = warn(msg)
+    def warn(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] = warn(t)(msg)
+    def error(ctx: Map[String, String])(msg: => String): F[Unit] = error(msg)
+    def error(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] = error(t)(msg)
+  }
+
   def apply[F[_]](implicit ev: StructuredLogger[F]): StructuredLogger[F] = ev
 
   def withContext[F[_]](sl: StructuredLogger[F])(ctx: Map[String, String]): StructuredLogger[F] =


### PR DESCRIPTION
This came up in discussion on https://github.com/http4s/http4s/pull/6629 about whether the http4s logging middleware should continue to allow the user to provide `String => F[Unit]` instead of `LoggerFactory` - allowing it adds implementation complexity, but currently it takes a tremendous amount of boilerplate to lift a `String => F[Unit]` into a `LoggerFactory`. cc @armanbilge 

Names and access modifiers subject to bikeshedding of course.