### PR TITLE
Deprecate implicit materialization of `Slf4jFactory`

### DIFF
--- a/core/shared/src/main/scala/org/typelevel/log4cats/LoggerFactoryGen.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/LoggerFactoryGen.scala
@@ -27,22 +27,16 @@ trait LoggerFactoryGen[F[_]] {
 }
 
 private[log4cats] trait LoggerFactoryGenCompanion {
-  @deprecated("LoggerFactories should be passed explicitly, not implicitly", "2.5.0")
   def getLogger[F[_]](implicit lf: LoggerFactoryGen[F], name: LoggerName): lf.LoggerType =
     lf.getLogger
-  @deprecated("LoggerFactories should be passed explicitly, not implicitly", "2.5.0")
   def getLoggerFromName[F[_]](name: String)(implicit lf: LoggerFactoryGen[F]): lf.LoggerType =
     lf.getLoggerFromName(name)
-  @deprecated("LoggerFactories should be passed explicitly, not implicitly", "2.5.0")
   def getLoggerFromClass[F[_]](clazz: Class[_])(implicit lf: LoggerFactoryGen[F]): lf.LoggerType =
     lf.getLoggerFromClass(clazz)
-  @deprecated("LoggerFactories should be passed explicitly, not implicitly", "2.5.0")
   def create[F[_]](implicit lf: LoggerFactoryGen[F], name: LoggerName): F[lf.LoggerType] =
     lf.create
-  @deprecated("LoggerFactories should be passed explicitly, not implicitly", "2.5.0")
   def fromName[F[_]](name: String)(implicit lf: LoggerFactoryGen[F]): F[lf.LoggerType] =
     lf.fromName(name)
-  @deprecated("LoggerFactories should be passed explicitly, not implicitly", "2.5.0")
   def fromClass[F[_]](clazz: Class[_])(implicit lf: LoggerFactoryGen[F]): F[lf.LoggerType] =
     lf.fromClass(clazz)
 }

--- a/core/shared/src/main/scala/org/typelevel/log4cats/LoggerFactoryGen.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/LoggerFactoryGen.scala
@@ -27,16 +27,22 @@ trait LoggerFactoryGen[F[_]] {
 }
 
 private[log4cats] trait LoggerFactoryGenCompanion {
+  @deprecated("LoggerFactories should be passed explicitly, not implicitly", "2.5.0")
   def getLogger[F[_]](implicit lf: LoggerFactoryGen[F], name: LoggerName): lf.LoggerType =
     lf.getLogger
+  @deprecated("LoggerFactories should be passed explicitly, not implicitly", "2.5.0")
   def getLoggerFromName[F[_]](name: String)(implicit lf: LoggerFactoryGen[F]): lf.LoggerType =
     lf.getLoggerFromName(name)
+  @deprecated("LoggerFactories should be passed explicitly, not implicitly", "2.5.0")
   def getLoggerFromClass[F[_]](clazz: Class[_])(implicit lf: LoggerFactoryGen[F]): lf.LoggerType =
     lf.getLoggerFromClass(clazz)
+  @deprecated("LoggerFactories should be passed explicitly, not implicitly", "2.5.0")
   def create[F[_]](implicit lf: LoggerFactoryGen[F], name: LoggerName): F[lf.LoggerType] =
     lf.create
+  @deprecated("LoggerFactories should be passed explicitly, not implicitly", "2.5.0")
   def fromName[F[_]](name: String)(implicit lf: LoggerFactoryGen[F]): F[lf.LoggerType] =
     lf.fromName(name)
+  @deprecated("LoggerFactories should be passed explicitly, not implicitly", "2.5.0")
   def fromClass[F[_]](clazz: Class[_])(implicit lf: LoggerFactoryGen[F]): F[lf.LoggerType] =
     lf.fromClass(clazz)
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,7 +100,7 @@ This brings several advantages:
 If you are unsure how to create a new `LoggerFactory[F]` instance, then you can look at the `log4cats-slf4j`,
 or `log4cats-noop` modules for concrete implementations.
 
-The quickest fix might to create an instance of a `Slf4jFactory` and pass it around implicitly:
+The quickest fix might be to create an instance of a `Slf4jFactory` and pass it around implicitly:
 ```scala mdoc:reset:silent
 import cats.effect.IO
 import cats.Monad

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,29 +100,17 @@ This brings several advantages:
 If you are unsure how to create a new `LoggerFactory[F]` instance, then you can look at the `log4cats-slf4j`,
 or `log4cats-noop` modules for concrete implementations.
 
-The quickest fix might be to import needed implicits:
-```scala mdoc:silent
-// assumes dependency on log4cats-slf4j module
-import org.typelevel.log4cats._
-import org.typelevel.log4cats.slf4j._
-
-val logger: SelfAwareStructuredLogger[IO] = LoggerFactory[IO].getLogger
-
-// or
-def anyFSyncLogger[F[_]: Sync]: SelfAwareStructuredLogger[F] = Slf4jFactory[F].getLogger
-```
-
-Alternatively, a mutually exclusive solution is to explicitly create your 
-`LoggerFactory[F]` instance and pass them around implicitly:
+The quickest fix might to create an instance of a `Slf4jFactory` and pass it around implicitly:
 ```scala mdoc:reset:silent
 import cats.effect.IO
 import cats.Monad
 import cats.syntax.all._
 import org.typelevel.log4cats._
+// assumes dependency on log4cats-slf4j module
 import org.typelevel.log4cats.slf4j.Slf4jFactory
 
 // create our LoggerFactory
-implicit val logging: LoggerFactory[IO] = Slf4jFactory[IO]
+implicit val logging: LoggerFactory[IO] = Slf4jFactory.create[IO]
 
 // we summon LoggerFactory instance, and create logger
 val logger: SelfAwareStructuredLogger[IO] = LoggerFactory[IO].getLogger

--- a/slf4j/src/main/scala/org/typelevel/log4cats/slf4j/Slf4jFactory.scala
+++ b/slf4j/src/main/scala/org/typelevel/log4cats/slf4j/Slf4jFactory.scala
@@ -17,6 +17,7 @@
 package org.typelevel.log4cats
 package slf4j
 
+import cats.effect.kernel.Sync
 import org.slf4j.{Logger => JLogger}
 
 trait Slf4jFactory[F[_]] extends LoggerFactory[F] {
@@ -27,6 +28,20 @@ trait Slf4jFactory[F[_]] extends LoggerFactory[F] {
 
 object Slf4jFactory extends LoggerFactoryGenCompanion {
   def apply[F[_]: Slf4jFactory]: Slf4jFactory[F] = implicitly
+
+  def create[F[_]: Sync]: Slf4jFactory[F] = new Slf4jFactory[F] {
+    override def getLoggerFromName(name: String): SelfAwareStructuredLogger[F] =
+      Slf4jLogger.getLoggerFromName(name)
+
+    override def getLoggerFromSlf4j(logger: JLogger): SelfAwareStructuredLogger[F] =
+      Slf4jLogger.getLoggerFromSlf4j(logger)
+
+    override def fromName(name: String): F[SelfAwareStructuredLogger[F]] =
+      Slf4jLogger.fromName(name)
+
+    override def fromSlf4j(logger: JLogger): F[SelfAwareStructuredLogger[F]] =
+      Slf4jLogger.fromSlf4j(logger)
+  }
 
   def getLoggerFromSlf4j[F[_]](logger: JLogger)(implicit
       lf: Slf4jFactory[F]

--- a/slf4j/src/main/scala/org/typelevel/log4cats/slf4j/Slf4jFactory.scala
+++ b/slf4j/src/main/scala/org/typelevel/log4cats/slf4j/Slf4jFactory.scala
@@ -17,7 +17,6 @@
 package org.typelevel.log4cats
 package slf4j
 
-import cats.effect.kernel.Sync
 import org.slf4j.{Logger => JLogger}
 
 trait Slf4jFactory[F[_]] extends LoggerFactory[F] {
@@ -27,22 +26,7 @@ trait Slf4jFactory[F[_]] extends LoggerFactory[F] {
 }
 
 object Slf4jFactory extends LoggerFactoryGenCompanion {
-  @deprecated("LoggerFactories should be passed explicitly, not implicitly", "2.5.0")
   def apply[F[_]: Slf4jFactory]: Slf4jFactory[F] = implicitly
-
-  def create[F[_]: Sync]: Slf4jFactory[F] = new Slf4jFactory[F] {
-    override def getLoggerFromName(name: String): SelfAwareStructuredLogger[F] =
-      Slf4jLogger.getLoggerFromName(name)
-
-    override def getLoggerFromSlf4j(logger: JLogger): SelfAwareStructuredLogger[F] =
-      Slf4jLogger.getLoggerFromSlf4j(logger)
-
-    override def fromName(name: String): F[SelfAwareStructuredLogger[F]] =
-      Slf4jLogger.fromName(name)
-
-    override def fromSlf4j(logger: JLogger): F[SelfAwareStructuredLogger[F]] =
-      Slf4jLogger.fromSlf4j(logger)
-  }
 
   def getLoggerFromSlf4j[F[_]](logger: JLogger)(implicit
       lf: Slf4jFactory[F]

--- a/slf4j/src/main/scala/org/typelevel/log4cats/slf4j/package.scala
+++ b/slf4j/src/main/scala/org/typelevel/log4cats/slf4j/package.scala
@@ -20,7 +20,7 @@ import cats.effect.Sync
 
 package object slf4j {
 
-  @deprecated("Use Slf4jFactory.create[F] explicitly", "2.5.0")
+  @deprecated("Use Slf4jFactory.create[F] explicitly", "2.6.0")
   implicit def loggerFactoryforSync[F[_]: Sync]: Slf4jFactory[F] =
     Slf4jFactory.create[F]
 }

--- a/slf4j/src/main/scala/org/typelevel/log4cats/slf4j/package.scala
+++ b/slf4j/src/main/scala/org/typelevel/log4cats/slf4j/package.scala
@@ -17,20 +17,10 @@
 package org.typelevel.log4cats
 
 import cats.effect.Sync
-import org.slf4j.{Logger => JLogger}
 
 package object slf4j {
-  implicit def loggerFactoryforSync[F[_]: Sync]: Slf4jFactory[F] = new Slf4jFactory[F] {
-    override def getLoggerFromName(name: String): SelfAwareStructuredLogger[F] =
-      Slf4jLogger.getLoggerFromName(name)
 
-    override def getLoggerFromSlf4j(logger: JLogger): SelfAwareStructuredLogger[F] =
-      Slf4jLogger.getLoggerFromSlf4j(logger)
-
-    override def fromName(name: String): F[SelfAwareStructuredLogger[F]] =
-      Slf4jLogger.fromName(name)
-
-    override def fromSlf4j(logger: JLogger): F[SelfAwareStructuredLogger[F]] =
-      Slf4jLogger.fromSlf4j(logger)
-  }
+  @deprecated("Use Slf4jFactory.create[F] explicitly", "2.5.0")
+  implicit def loggerFactoryforSync[F[_]: Sync]: Slf4jFactory[F] =
+    Slf4jFactory.create[F]
 }

--- a/slf4j/src/main/scala/org/typelevel/log4cats/slf4j/package.scala
+++ b/slf4j/src/main/scala/org/typelevel/log4cats/slf4j/package.scala
@@ -17,20 +17,10 @@
 package org.typelevel.log4cats
 
 import cats.effect.Sync
-import org.slf4j.{Logger => JLogger}
 
 package object slf4j {
-  implicit def loggerFactoryforSync[F[_]: Sync]: Slf4jFactory[F] = new Slf4jFactory[F] {
-    override def getLoggerFromName(name: String): SelfAwareStructuredLogger[F] =
-      Slf4jLogger.getLoggerFromName(name)
 
-    override def getLoggerFromSlf4j(logger: JLogger): SelfAwareStructuredLogger[F] =
-      Slf4jLogger.getLoggerFromSlf4j(logger)
-
-    override def fromName(name: String): F[SelfAwareStructuredLogger[F]] =
-      Slf4jLogger.fromName(name)
-
-    override def fromSlf4j(logger: JLogger): F[SelfAwareStructuredLogger[F]] =
-      Slf4jLogger.fromSlf4j(logger)
-  }
+  @deprecated("LoggerFactories should be passed explicitly, not implicitly", "2.5.0")
+  implicit def loggerFactoryforSync[F[_]](implicit F: Sync[F]): Slf4jFactory[F] =
+    Slf4jFactory.create(F)
 }

--- a/slf4j/src/main/scala/org/typelevel/log4cats/slf4j/package.scala
+++ b/slf4j/src/main/scala/org/typelevel/log4cats/slf4j/package.scala
@@ -17,10 +17,20 @@
 package org.typelevel.log4cats
 
 import cats.effect.Sync
+import org.slf4j.{Logger => JLogger}
 
 package object slf4j {
+  implicit def loggerFactoryforSync[F[_]: Sync]: Slf4jFactory[F] = new Slf4jFactory[F] {
+    override def getLoggerFromName(name: String): SelfAwareStructuredLogger[F] =
+      Slf4jLogger.getLoggerFromName(name)
 
-  @deprecated("LoggerFactories should be passed explicitly, not implicitly", "2.5.0")
-  implicit def loggerFactoryforSync[F[_]](implicit F: Sync[F]): Slf4jFactory[F] =
-    Slf4jFactory.create(F)
+    override def getLoggerFromSlf4j(logger: JLogger): SelfAwareStructuredLogger[F] =
+      Slf4jLogger.getLoggerFromSlf4j(logger)
+
+    override def fromName(name: String): F[SelfAwareStructuredLogger[F]] =
+      Slf4jLogger.fromName(name)
+
+    override def fromSlf4j(logger: JLogger): F[SelfAwareStructuredLogger[F]] =
+      Slf4jLogger.fromSlf4j(logger)
+  }
 }

--- a/slf4j/src/test/scala/org/typelevel/log4cats/slf4j/Slf4jLoggerMacroCompilationTests.scala
+++ b/slf4j/src/test/scala/org/typelevel/log4cats/slf4j/Slf4jLoggerMacroCompilationTests.scala
@@ -48,7 +48,7 @@ class Slf4jLoggerOuterClassMacroTest {
 
 object LoggingBaseline {
   val t = new Throwable
-  def logger[F[_]: Sync]: SelfAwareStructuredLogger[F] = Slf4jFactory.getLogger[F]
+  def logger[F[_]: Sync]: SelfAwareStructuredLogger[F] = Slf4jFactory.create[F].getLogger
 
   val traceM = logger[IO].trace("")
   val traceTM = logger[IO].trace(t)("")

--- a/slf4j/src/test/scala/org/typelevel/log4cats/slf4j/Slf4jLoggerMacroCompilationTests.scala
+++ b/slf4j/src/test/scala/org/typelevel/log4cats/slf4j/Slf4jLoggerMacroCompilationTests.scala
@@ -48,7 +48,7 @@ class Slf4jLoggerOuterClassMacroTest {
 
 object LoggingBaseline {
   val t = new Throwable
-  def logger[F[_]: Sync]: SelfAwareStructuredLogger[F] = Slf4jFactory.create[F].getLogger
+  def logger[F[_]: Sync]: SelfAwareStructuredLogger[F] = Slf4jFactory.getLogger[F]
 
   val traceM = logger[IO].trace("")
   val traceTM = logger[IO].trace(t)("")


### PR DESCRIPTION
See https://github.com/typelevel/log4cats/pull/681#issuecomment-1224535985. Since there is not one canonical `LoggerFactory` implementation, they should be passed explicitly, not implicitly.

Closes https://github.com/typelevel/log4cats/pull/681.