### PR TITLE
implement ConsoleLogger for Scala.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,11 +119,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p testing/jvm/target noop/jvm/target target .js/target core/native/target site/target testing/native/target noop/native/target core/js/target testing/js/target noop/js/target core/jvm/target .jvm/target .native/target slf4j/target project/target
+        run: mkdir -p testing/jvm/target noop/jvm/target target .js/target core/native/target site/target testing/native/target noop/native/target core/js/target js-console/target testing/js/target noop/js/target core/jvm/target .jvm/target .native/target slf4j/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar testing/jvm/target noop/jvm/target target .js/target core/native/target site/target testing/native/target noop/native/target core/js/target testing/js/target noop/js/target core/jvm/target .jvm/target .native/target slf4j/target project/target
+        run: tar cf targets.tar testing/jvm/target noop/jvm/target target .js/target core/native/target site/target testing/native/target noop/native/target core/js/target js-console/target testing/js/target noop/js/target core/jvm/target .jvm/target .native/target slf4j/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ lazy val `js-console` = project
     name := "log4cats-js-console",
     tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "2.6.0").toMap,
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-effect" % catsEffectV
+      "org.typelevel" %%% "cats-effect-kernel" % catsEffectV
     )
   )
   .enablePlugins(ScalaJSPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ val logbackClassicV = "1.2.11"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-lazy val root = tlCrossRootProject.aggregate(core, testing, noop, slf4j, docs)
+lazy val root = tlCrossRootProject.aggregate(core, testing, noop, slf4j, docs, `js-console`)
 
 lazy val docs = project
   .in(file("site"))
@@ -91,6 +91,18 @@ lazy val slf4j = project
       else Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided)
     }
   )
+
+lazy val `js-console` = project
+  .settings(commonSettings)
+  .dependsOn(core.js)
+  .settings(
+    name := "log4cats-js-console",
+    tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "2.6.0").toMap,
+    libraryDependencies ++= Seq(
+      "org.typelevel" %%% "cats-effect" % catsEffectV,
+    )
+  )
+  .enablePlugins(ScalaJSPlugin)
 
 lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ lazy val `js-console` = project
     name := "log4cats-js-console",
     tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "2.6.0").toMap,
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-effect" % catsEffectV,
+      "org.typelevel" %%% "cats-effect" % catsEffectV
     )
   )
   .enablePlugins(ScalaJSPlugin)

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/Console.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/Console.scala
@@ -1,0 +1,41 @@
+/** All documentation for facades is thanks to Mozilla Contributors at https://developer.mozilla.org/en-US/docs/Web/API
+ * and available under the Creative Commons Attribution-ShareAlike v2.5 or later.
+ * http://creativecommons.org/licenses/by-sa/2.5/
+ *
+ * Everything else is under the MIT License http://opensource.org/licenses/MIT
+ */
+package org.typelevel.log4cats.console
+
+import scala.annotation.nowarn
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobal
+
+/** The console object provides access to the browser's debugging console. The specifics of how it works vary from
+ * browser to browser, but there is a de facto set of features that are typically provided.
+ *
+ * There are more methods available; this is the minimal façade needed for console logging from log4cats.
+ */
+@js.native
+@JSGlobal("console")
+@nowarn("msg=parameter value .+ in method .+ is never used")
+object Console extends js.Object {
+  /** Outputs an informational message to the Web Console. In Firefox, a small "i" icon is displayed next to these items
+   * in the Web Console's log.
+   */
+  def info(message: Any, optionalParams: Any*): Unit = js.native
+
+  /** Outputs a warning message. You may use string substitution and additional arguments with this method. See Using
+   * string substitutions.
+   */
+  def warn(message: Any, optionalParams: Any*): Unit = js.native
+
+  /** Outputs an error message. You may use string substitution and additional arguments with this method. See Using
+   * string substitutions.
+   */
+  def error(message: Any, optionalParams: Any*): Unit = js.native
+
+  /** Outputs a debug message. You may use string substitution and additional arguments with this method. See Using
+   * string substitutions.
+   */
+  def debug(message: Any, optionalParams: Any*): Unit = js.native
+}

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/Console.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/Console.scala
@@ -23,7 +23,6 @@
 
 package org.typelevel.log4cats.console
 
-import scala.annotation.nowarn
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSGlobal
 
@@ -37,8 +36,7 @@ import scala.scalajs.js.annotation.JSGlobal
  */
 @js.native
 @JSGlobal("console")
-@nowarn("msg=parameter value .+ in method .+ is never used")
-object Console extends js.Object {
+private[console] object Console extends js.Object {
 
   /**
    * Outputs an informational message to the Web Console. In Firefox, a small "i" icon is displayed

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/Console.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/Console.scala
@@ -1,9 +1,26 @@
-/** All documentation for facades is thanks to Mozilla Contributors at https://developer.mozilla.org/en-US/docs/Web/API
+/*
+ * Copyright 2018 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* All documentation for facades is thanks to Mozilla Contributors at https://developer.mozilla.org/en-US/docs/Web/API
  * and available under the Creative Commons Attribution-ShareAlike v2.5 or later.
  * http://creativecommons.org/licenses/by-sa/2.5/
  *
  * Everything else is under the MIT License http://opensource.org/licenses/MIT
  */
+
 package org.typelevel.log4cats.console
 
 import scala.annotation.nowarn

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/Console.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/Console.scala
@@ -27,32 +27,40 @@ import scala.annotation.nowarn
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSGlobal
 
-/** The console object provides access to the browser's debugging console. The specifics of how it works vary from
- * browser to browser, but there is a de facto set of features that are typically provided.
+/**
+ * The console object provides access to the browser's debugging console. The specifics of how it
+ * works vary from browser to browser, but there is a de facto set of features that are typically
+ * provided.
  *
- * There are more methods available; this is the minimal façade needed for console logging from log4cats.
+ * There are more methods available; this is the minimal façade needed for console logging from
+ * log4cats.
  */
 @js.native
 @JSGlobal("console")
 @nowarn("msg=parameter value .+ in method .+ is never used")
 object Console extends js.Object {
-  /** Outputs an informational message to the Web Console. In Firefox, a small "i" icon is displayed next to these items
-   * in the Web Console's log.
+
+  /**
+   * Outputs an informational message to the Web Console. In Firefox, a small "i" icon is displayed
+   * next to these items in the Web Console's log.
    */
   def info(message: Any, optionalParams: Any*): Unit = js.native
 
-  /** Outputs a warning message. You may use string substitution and additional arguments with this method. See Using
-   * string substitutions.
+  /**
+   * Outputs a warning message. You may use string substitution and additional arguments with this
+   * method. See Using string substitutions.
    */
   def warn(message: Any, optionalParams: Any*): Unit = js.native
 
-  /** Outputs an error message. You may use string substitution and additional arguments with this method. See Using
-   * string substitutions.
+  /**
+   * Outputs an error message. You may use string substitution and additional arguments with this
+   * method. See Using string substitutions.
    */
   def error(message: Any, optionalParams: Any*): Unit = js.native
 
-  /** Outputs a debug message. You may use string substitution and additional arguments with this method. See Using
-   * string substitutions.
+  /**
+   * Outputs a debug message. You may use string substitution and additional arguments with this
+   * method. See Using string substitutions.
    */
   def debug(message: Any, optionalParams: Any*): Unit = js.native
 }

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleF.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleF.scala
@@ -17,7 +17,7 @@
 package org.typelevel.log4cats
 package console
 
-import cats.effect.Sync
+import cats.effect.kernel.Sync
 
 class ConsoleF[F[_]: Sync] {
   def info(message: Any, optionalParams: Any*): F[Unit] =

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleF.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleF.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.typelevel.log4cats
 package console
 

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleF.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleF.scala
@@ -19,7 +19,7 @@ package console
 
 import cats.effect.kernel.Sync
 
-class ConsoleF[F[_]: Sync] {
+private[console] class ConsoleF[F[_]: Sync] {
   def info(message: Any, optionalParams: Any*): F[Unit] =
     Sync[F].delay(Console.info(message, optionalParams: _*))
   def warn(message: Any, optionalParams: Any*): F[Unit] =
@@ -30,7 +30,7 @@ class ConsoleF[F[_]: Sync] {
     Sync[F].delay(Console.debug(message, optionalParams: _*))
 }
 
-object ConsoleF {
+private[console] object ConsoleF {
   def apply[F[_]: ConsoleF]: ConsoleF[F] = implicitly
 
   implicit def syncInstance[F[_]: Sync]: ConsoleF[F] = new ConsoleF[F]

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleF.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleF.scala
@@ -1,0 +1,17 @@
+package org.typelevel.log4cats
+package console
+
+import cats.effect.Sync
+
+class ConsoleF[F[_] : Sync] {
+  def info(message: Any, optionalParams: Any*): F[Unit] = Sync[F].delay(Console.info(message, optionalParams:_*))
+  def warn(message: Any, optionalParams: Any*): F[Unit] = Sync[F].delay(Console.warn(message, optionalParams:_*))
+  def error(message: Any, optionalParams: Any*): F[Unit] = Sync[F].delay(Console.error(message, optionalParams:_*))
+  def debug(message: Any, optionalParams: Any*): F[Unit] = Sync[F].delay(Console.debug(message, optionalParams:_*))
+}
+
+object ConsoleF {
+  def apply[F[_] : ConsoleF]: ConsoleF[F] = implicitly
+
+  implicit def syncInstance[F[_] : Sync]: ConsoleF[F] = new ConsoleF[F]
+}

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleF.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleF.scala
@@ -19,15 +19,19 @@ package console
 
 import cats.effect.Sync
 
-class ConsoleF[F[_] : Sync] {
-  def info(message: Any, optionalParams: Any*): F[Unit] = Sync[F].delay(Console.info(message, optionalParams:_*))
-  def warn(message: Any, optionalParams: Any*): F[Unit] = Sync[F].delay(Console.warn(message, optionalParams:_*))
-  def error(message: Any, optionalParams: Any*): F[Unit] = Sync[F].delay(Console.error(message, optionalParams:_*))
-  def debug(message: Any, optionalParams: Any*): F[Unit] = Sync[F].delay(Console.debug(message, optionalParams:_*))
+class ConsoleF[F[_]: Sync] {
+  def info(message: Any, optionalParams: Any*): F[Unit] =
+    Sync[F].delay(Console.info(message, optionalParams: _*))
+  def warn(message: Any, optionalParams: Any*): F[Unit] =
+    Sync[F].delay(Console.warn(message, optionalParams: _*))
+  def error(message: Any, optionalParams: Any*): F[Unit] =
+    Sync[F].delay(Console.error(message, optionalParams: _*))
+  def debug(message: Any, optionalParams: Any*): F[Unit] =
+    Sync[F].delay(Console.debug(message, optionalParams: _*))
 }
 
 object ConsoleF {
-  def apply[F[_] : ConsoleF]: ConsoleF[F] = implicitly
+  def apply[F[_]: ConsoleF]: ConsoleF[F] = implicitly
 
-  implicit def syncInstance[F[_] : Sync]: ConsoleF[F] = new ConsoleF[F]
+  implicit def syncInstance[F[_]: Sync]: ConsoleF[F] = new ConsoleF[F]
 }

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLogger.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLogger.scala
@@ -17,14 +17,14 @@
 package org.typelevel.log4cats
 package console
 
-import cats._
+import cats.effect.kernel.Sync
 import cats.syntax.all._
 import org.typelevel.log4cats.extras.LogLevel
 import org.typelevel.log4cats.extras.LogLevel._
 
-class ConsoleLogger[F[_]: Applicative](logLevel: Option[LogLevel] = Option(Trace))(implicit
-    ConsoleF: ConsoleF[F]
-) extends SelfAwareStructuredLogger[F] {
+class ConsoleLogger[F[_]: Sync](logLevel: Option[LogLevel] = Option(Trace))
+    extends SelfAwareStructuredLogger[F] {
+  private val ConsoleF: ConsoleF[F] = implicitly
   override def trace(t: Throwable)(message: => String): F[Unit] = ConsoleF.debug(message, t)
   override def trace(message: => String): F[Unit] = ConsoleF.debug(message)
   override def isTraceEnabled: F[Boolean] = logLevel.exists(_ <= Trace).pure[F]

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLogger.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLogger.scala
@@ -20,7 +20,7 @@ package console
 import cats._
 import cats.syntax.all._
 
-class ConsoleLogger[F[_] : Applicative : ConsoleF] extends SelfAwareStructuredLogger[F] {
+class ConsoleLogger[F[_]: Applicative: ConsoleF] extends SelfAwareStructuredLogger[F] {
   override def trace(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].debug(message, t)
   override def trace(message: => String): F[Unit] = ConsoleF[F].debug(message)
   override def isTraceEnabled: F[Boolean] = true.pure[F]
@@ -50,13 +50,16 @@ class ConsoleLogger[F[_] : Applicative : ConsoleF] extends SelfAwareStructuredLo
    * map parameters.
    */
   override def trace(ctx: Map[String, String])(msg: => String): F[Unit] = trace(msg)
-  override def trace(ctx: Map[String, String], t: Throwable)(msg: =>String): F[Unit] = trace(t)(msg)
-  override def debug(ctx: Map[String, String])(msg: =>String): F[Unit] = debug(msg)
-  override def debug(ctx: Map[String, String], t: Throwable)(msg: =>String): F[Unit] = debug(t)(msg)
-  override def info(ctx: Map[String, String])(msg: =>String): F[Unit] = info(msg)
-  override def info(ctx: Map[String, String], t: Throwable)(msg: =>String): F[Unit] = info(t)(msg)
-  override def warn(ctx: Map[String, String])(msg: =>String): F[Unit] = warn(msg)
-  override def warn(ctx: Map[String, String], t: Throwable)(msg: =>String): F[Unit] = warn(t)(msg)
-  override def error(ctx: Map[String, String])(msg: =>String): F[Unit] = error(msg)
-  override def error(ctx: Map[String, String], t: Throwable)(msg: =>String): F[Unit] = error(t)(msg)
+  override def trace(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+    trace(t)(msg)
+  override def debug(ctx: Map[String, String])(msg: => String): F[Unit] = debug(msg)
+  override def debug(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+    debug(t)(msg)
+  override def info(ctx: Map[String, String])(msg: => String): F[Unit] = info(msg)
+  override def info(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] = info(t)(msg)
+  override def warn(ctx: Map[String, String])(msg: => String): F[Unit] = warn(msg)
+  override def warn(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] = warn(t)(msg)
+  override def error(ctx: Map[String, String])(msg: => String): F[Unit] = error(msg)
+  override def error(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+    error(t)(msg)
 }

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLogger.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLogger.scala
@@ -19,27 +19,30 @@ package console
 
 import cats._
 import cats.syntax.all._
+import org.typelevel.log4cats.extras.LogLevel
+import org.typelevel.log4cats.extras.LogLevel._
 
-class ConsoleLogger[F[_]: Applicative: ConsoleF] extends SelfAwareStructuredLogger[F] {
+class ConsoleLogger[F[_]: Applicative: ConsoleF](logLevel: Option[LogLevel] = Option(Trace))
+    extends SelfAwareStructuredLogger[F] {
   override def trace(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].debug(message, t)
   override def trace(message: => String): F[Unit] = ConsoleF[F].debug(message)
-  override def isTraceEnabled: F[Boolean] = true.pure[F]
+  override def isTraceEnabled: F[Boolean] = logLevel.exists(_ <= Trace).pure[F]
 
   override def debug(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].debug(message, t)
   override def debug(message: => String): F[Unit] = ConsoleF[F].debug(message)
-  override def isDebugEnabled: F[Boolean] = true.pure[F]
+  override def isDebugEnabled: F[Boolean] = logLevel.exists(_ <= Debug).pure[F]
 
   override def info(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].info(message, t)
   override def info(message: => String): F[Unit] = ConsoleF[F].info(message)
-  override def isInfoEnabled: F[Boolean] = true.pure[F]
+  override def isInfoEnabled: F[Boolean] = logLevel.exists(_ <= Info).pure[F]
 
   override def warn(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].warn(message, t)
   override def warn(message: => String): F[Unit] = ConsoleF[F].warn(message)
-  override def isWarnEnabled: F[Boolean] = true.pure[F]
+  override def isWarnEnabled: F[Boolean] = logLevel.exists(_ <= Warn).pure[F]
 
   override def error(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].error(message, t)
   override def error(message: => String): F[Unit] = ConsoleF[F].error(message)
-  override def isErrorEnabled: F[Boolean] = true.pure[F]
+  override def isErrorEnabled: F[Boolean] = logLevel.exists(_ <= Error).pure[F]
 
   /*
    * ConsoleLogger should probably not extend from StructuredLogger, because there's not

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLogger.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLogger.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.typelevel.log4cats
 package console
 

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLogger.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLogger.scala
@@ -1,0 +1,46 @@
+package org.typelevel.log4cats
+package console
+
+import cats._
+import cats.syntax.all._
+
+class ConsoleLogger[F[_] : Applicative : ConsoleF] extends SelfAwareStructuredLogger[F] {
+  override def trace(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].debug(message, t)
+  override def trace(message: => String): F[Unit] = ConsoleF[F].debug(message)
+  override def isTraceEnabled: F[Boolean] = true.pure[F]
+
+  override def debug(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].debug(message, t)
+  override def debug(message: => String): F[Unit] = ConsoleF[F].debug(message)
+  override def isDebugEnabled: F[Boolean] = true.pure[F]
+
+  override def info(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].info(message, t)
+  override def info(message: => String): F[Unit] = ConsoleF[F].info(message)
+  override def isInfoEnabled: F[Boolean] = true.pure[F]
+
+  override def warn(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].warn(message, t)
+  override def warn(message: => String): F[Unit] = ConsoleF[F].warn(message)
+  override def isWarnEnabled: F[Boolean] = true.pure[F]
+
+  override def error(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].error(message, t)
+  override def error(message: => String): F[Unit] = ConsoleF[F].error(message)
+  override def isErrorEnabled: F[Boolean] = true.pure[F]
+
+  /*
+   * ConsoleLogger should probably not extend from StructuredLogger, because there's not
+   * a good way to use the context map on this platform. However, LoggerFactory forces
+   * its LoggerType to extend SelfAwareStructuredLogger, and since that's the factory
+   * type that is well documented, that's what is demanded everywhere. Therefore, to be
+   * useful, we implement the context variants below, but completely ignore the context
+   * map parameters.
+   */
+  override def trace(ctx: Map[String, String])(msg: => String): F[Unit] = trace(msg)
+  override def trace(ctx: Map[String, String], t: Throwable)(msg: =>String): F[Unit] = trace(t)(msg)
+  override def debug(ctx: Map[String, String])(msg: =>String): F[Unit] = debug(msg)
+  override def debug(ctx: Map[String, String], t: Throwable)(msg: =>String): F[Unit] = debug(t)(msg)
+  override def info(ctx: Map[String, String])(msg: =>String): F[Unit] = info(msg)
+  override def info(ctx: Map[String, String], t: Throwable)(msg: =>String): F[Unit] = info(t)(msg)
+  override def warn(ctx: Map[String, String])(msg: =>String): F[Unit] = warn(msg)
+  override def warn(ctx: Map[String, String], t: Throwable)(msg: =>String): F[Unit] = warn(t)(msg)
+  override def error(ctx: Map[String, String])(msg: =>String): F[Unit] = error(msg)
+  override def error(ctx: Map[String, String], t: Throwable)(msg: =>String): F[Unit] = error(t)(msg)
+}

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLogger.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLogger.scala
@@ -22,26 +22,27 @@ import cats.syntax.all._
 import org.typelevel.log4cats.extras.LogLevel
 import org.typelevel.log4cats.extras.LogLevel._
 
-class ConsoleLogger[F[_]: Applicative: ConsoleF](logLevel: Option[LogLevel] = Option(Trace))
-    extends SelfAwareStructuredLogger[F] {
-  override def trace(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].debug(message, t)
-  override def trace(message: => String): F[Unit] = ConsoleF[F].debug(message)
+class ConsoleLogger[F[_]: Applicative](logLevel: Option[LogLevel] = Option(Trace))(implicit
+    ConsoleF: ConsoleF[F]
+) extends SelfAwareStructuredLogger[F] {
+  override def trace(t: Throwable)(message: => String): F[Unit] = ConsoleF.debug(message, t)
+  override def trace(message: => String): F[Unit] = ConsoleF.debug(message)
   override def isTraceEnabled: F[Boolean] = logLevel.exists(_ <= Trace).pure[F]
 
-  override def debug(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].debug(message, t)
-  override def debug(message: => String): F[Unit] = ConsoleF[F].debug(message)
+  override def debug(t: Throwable)(message: => String): F[Unit] = ConsoleF.debug(message, t)
+  override def debug(message: => String): F[Unit] = ConsoleF.debug(message)
   override def isDebugEnabled: F[Boolean] = logLevel.exists(_ <= Debug).pure[F]
 
-  override def info(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].info(message, t)
-  override def info(message: => String): F[Unit] = ConsoleF[F].info(message)
+  override def info(t: Throwable)(message: => String): F[Unit] = ConsoleF.info(message, t)
+  override def info(message: => String): F[Unit] = ConsoleF.info(message)
   override def isInfoEnabled: F[Boolean] = logLevel.exists(_ <= Info).pure[F]
 
-  override def warn(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].warn(message, t)
-  override def warn(message: => String): F[Unit] = ConsoleF[F].warn(message)
+  override def warn(t: Throwable)(message: => String): F[Unit] = ConsoleF.warn(message, t)
+  override def warn(message: => String): F[Unit] = ConsoleF.warn(message)
   override def isWarnEnabled: F[Boolean] = logLevel.exists(_ <= Warn).pure[F]
 
-  override def error(t: Throwable)(message: => String): F[Unit] = ConsoleF[F].error(message, t)
-  override def error(message: => String): F[Unit] = ConsoleF[F].error(message)
+  override def error(t: Throwable)(message: => String): F[Unit] = ConsoleF.error(message, t)
+  override def error(message: => String): F[Unit] = ConsoleF.error(message)
   override def isErrorEnabled: F[Boolean] = logLevel.exists(_ <= Error).pure[F]
 
   /*

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLoggerFactory.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLoggerFactory.scala
@@ -20,13 +20,16 @@ package console
 import cats.effect._
 import cats.syntax.all._
 
-class ConsoleLoggerFactory[F[_]: Sync] extends LoggerFactory[F] {
-  override def getLoggerFromName(name: String): SelfAwareStructuredLogger[F] =
-    new ConsoleLogger[F]()
-  override def fromName(name: String): F[SelfAwareStructuredLogger[F]] =
-    getLoggerFromName(name).pure[F].widen
-}
+trait ConsoleLoggerFactory[F[_]] extends LoggerFactory[F]
 
 object ConsoleLoggerFactory {
-  def apply[F[_]: Sync]: ConsoleLoggerFactory[F] = new ConsoleLoggerFactory[F]
+  def apply[F[_]: ConsoleLoggerFactory]: ConsoleLoggerFactory[F] = implicitly
+
+  def create[F[_]: Sync]: ConsoleLoggerFactory[F] = new ConsoleLoggerFactory[F] {
+    override def getLoggerFromName(name: String): SelfAwareStructuredLogger[F] =
+      new ConsoleLogger[F]()
+
+    override def fromName(name: String): F[SelfAwareStructuredLogger[F]] =
+      getLoggerFromName(name).pure[F].widen
+  }
 }

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLoggerFactory.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLoggerFactory.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.typelevel.log4cats
 package console
 

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLoggerFactory.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLoggerFactory.scala
@@ -20,11 +20,12 @@ package console
 import cats.effect._
 import cats.syntax.all._
 
-class ConsoleLoggerFactory[F[_] : Sync] extends LoggerFactory[F] {
+class ConsoleLoggerFactory[F[_]: Sync] extends LoggerFactory[F] {
   override def getLoggerFromName(name: String): SelfAwareStructuredLogger[F] = new ConsoleLogger[F]
-  override def fromName(name: String): F[SelfAwareStructuredLogger[F]] = getLoggerFromName(name).pure[F].widen
+  override def fromName(name: String): F[SelfAwareStructuredLogger[F]] =
+    getLoggerFromName(name).pure[F].widen
 }
 
 object ConsoleLoggerFactory {
-  def apply[F[_] : Sync]: ConsoleLoggerFactory[F] = new ConsoleLoggerFactory[F]
+  def apply[F[_]: Sync]: ConsoleLoggerFactory[F] = new ConsoleLoggerFactory[F]
 }

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLoggerFactory.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLoggerFactory.scala
@@ -17,7 +17,7 @@
 package org.typelevel.log4cats
 package console
 
-import cats.effect._
+import cats.effect.kernel._
 import cats.syntax.all._
 
 trait ConsoleLoggerFactory[F[_]] extends LoggerFactory[F]

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLoggerFactory.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLoggerFactory.scala
@@ -1,0 +1,14 @@
+package org.typelevel.log4cats
+package console
+
+import cats.effect._
+import cats.syntax.all._
+
+class ConsoleLoggerFactory[F[_] : Sync] extends LoggerFactory[F] {
+  override def getLoggerFromName(name: String): SelfAwareStructuredLogger[F] = new ConsoleLogger[F]
+  override def fromName(name: String): F[SelfAwareStructuredLogger[F]] = getLoggerFromName(name).pure[F].widen
+}
+
+object ConsoleLoggerFactory {
+  def apply[F[_] : Sync]: ConsoleLoggerFactory[F] = new ConsoleLoggerFactory[F]
+}

--- a/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLoggerFactory.scala
+++ b/js-console/src/main/scala/org/typelevel/log4cats/console/ConsoleLoggerFactory.scala
@@ -21,7 +21,8 @@ import cats.effect._
 import cats.syntax.all._
 
 class ConsoleLoggerFactory[F[_]: Sync] extends LoggerFactory[F] {
-  override def getLoggerFromName(name: String): SelfAwareStructuredLogger[F] = new ConsoleLogger[F]
+  override def getLoggerFromName(name: String): SelfAwareStructuredLogger[F] =
+    new ConsoleLogger[F]()
   override def fromName(name: String): F[SelfAwareStructuredLogger[F]] =
     getLoggerFromName(name).pure[F].widen
 }


### PR DESCRIPTION
A basic implementation to close #680 and make logging available on Scala.js.