### PR TITLE
Analyzable tags

### DIFF
--- a/core/shared/src/main/scala/org/typelevel/log4cats/PagingSelfAwareStructuredLogger.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/PagingSelfAwareStructuredLogger.scala
@@ -120,12 +120,15 @@ object PagingSelfAwareStructuredLogger {
     ): F[(String, Map[String, String])] =
       randomUUID.map { uuid =>
         val logSplitId = uuid.show
+        val msgLength = msg.length.show
         (
           logSplitId,
           ctx
             .updated(logSplitIdN, logSplitId)
             .updated("page_size", s"${pageSizeK.show} Kib")
-            .updated("log_size", s"${msg.length.show} Byte")
+            .updated("log_size_bytes", msgLength)
+            // The following is deprecated
+            .updated("log_size", s"${msgLength} Byte")
         )
       }
 

--- a/core/shared/src/main/scala/org/typelevel/log4cats/PagingSelfAwareStructuredLogger.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/PagingSelfAwareStructuredLogger.scala
@@ -87,8 +87,8 @@ object PagingSelfAwareStructuredLogger {
     private val pageSize = pageSizeK * 1024
 
     private def pagedLogging(
-      logOpWithCtx: Map[String, String] => (=> String) => F[Unit],
-      ctx: Map[String, String],
+        logOpWithCtx: Map[String, String] => (=> String) => F[Unit],
+        ctx: Map[String, String],
         logSplitId: String,
         msg: => String
     ): F[Unit] = {
@@ -136,10 +136,10 @@ object PagingSelfAwareStructuredLogger {
       }
 
     private def addPageCtx(
-      page: => String,
-      pageNum: => Int,
-      totalPages: => Int,
-      ctx: Map[String, String]
+        page: => String,
+        pageNum: => Int,
+        totalPages: => Int,
+        ctx: Map[String, String]
     ): Map[String, String] =
       ctx
         .updated("total_pages", totalPages.show)


### PR DESCRIPTION
Changes the tag behavior for a few of the tags on the Paged logger. The current tags seem optimized for human readability, not machine analytics. These changes allow metrics and dashboards to be created off of the tags without having to do a lot of pre-processing. This basically adds a bit more data about sizing, and creates some tags for data currently only added to the log message itself.

- Introduce a new field `log_size_bytes` for the new behavior, while leaving the old tag alone and deprecating it. This way we don't break existing behavior. In a major release we could switch this.
- Log size should log the size of _this_ log message, not the whole log. This allows summing of `log_size_bytes` to reflect the total logged volume without multi-counting paged messages. This is important to allow accurate monitoring of log volume.
- `page_number` and `total_pages` added as tags to the log messages. This allows filters to be created counting number of messages, without multi counting pages messages. Without this, querying would typically have to be accomplished with regex text searching, which is slower and brittle.