### PR TITLE
Minor cleanup in PagingSelfAwareStructuredLogger

### DIFF
--- a/core/shared/src/main/scala/org/typelevel/log4cats/PagingSelfAwareStructuredLogger.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/PagingSelfAwareStructuredLogger.scala
@@ -123,15 +123,15 @@ object PagingSelfAwareStructuredLogger {
     ): F[(String, Map[String, String])] =
       randomUUID.map { uuid =>
         val logSplitId = uuid.show
-        val msgLength = msg.length.show
+        val msgLength = msg.length
         (
           logSplitId,
           ctx
             .updated(logSplitIdN, logSplitId)
-            .updated("page_size", s"${pageSizeK.show} Kib")
-            .updated("whole_message_size_bytes", msgLength)
+            .updated("page_size", s"$pageSizeK Kib")
+            .updated("whole_message_size_bytes", s"$msgLength")
             // The following is deprecated
-            .updated("log_size", s"${msgLength} Byte")
+            .updated("log_size", s"$msgLength Byte")
         )
       }
 
@@ -142,9 +142,9 @@ object PagingSelfAwareStructuredLogger {
         ctx: Map[String, String]
     ): Map[String, String] =
       ctx
-        .updated("total_pages", totalPages.show)
-        .updated("page_num", pageNum.show)
-        .updated("log_size_bytes", page.length.show)
+        .updated("total_pages", s"$totalPages")
+        .updated("page_num", s"$pageNum")
+        .updated("log_size_bytes", s"${page.length}")
 
     private def doLogging(
         loggingLevelChk: => F[Boolean],


### PR DESCRIPTION
Materialize the paged message before interacting with it.
    
Previously the message would be materialized multiple times:
   - `1` : in call to `addMsgCtx` 
   - `3` or `1 + 3p` : in call to `pagedLogging`
     - Lower Bound (single page): `3`
       - `1` : calculate the number of pages
       - `1` : in call to `addPageCtx` (calculate the page length)
   	   - `1` : in call to `logOpWithCtx`
     - Upper Bound (`p` pages): `1 + 3p`
       - `1` : calculate the number of pages
       - `1p` : `msg` is materialized every time a page is sliced from the message
       - `1p` : in call to `addPageCtx` (calculate the page length)
       - `1p` : in call to `logOpWithCtx`
    
Materializing early gives these improvements:
   - Single page: from `4` times to `1` time
   - Multiple pages: from `2 + 3p` times to `1` time
    
Removes some by-name parameters that were always called with materialized values.

Simplifies unneeded calls to `Show` on `Int` or `String` values, which doesn't have any particular benefit, particularly if it's inside of a string interpolation anyway. 