### PR TITLE
Reimplement contextLog to populate MDC even when disabled

### DIFF
--- a/slf4j/src/test/scala/org/typelevel/log4cats/slf4j/internal/Slf4jLoggerInternalSuite.scala
+++ b/slf4j/src/test/scala/org/typelevel/log4cats/slf4j/internal/Slf4jLoggerInternalSuite.scala
@@ -21,21 +21,19 @@ import cats.arrow.FunctionK
 import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, Resource, SyncIO}
 import cats.syntax.all.*
-
-import java.util.concurrent.{Executors, ThreadFactory}
-import org.slf4j.MDC
 import munit.{CatsEffectSuite, Location}
+import org.slf4j.MDC
 import org.typelevel.log4cats.extras.DeferredLogMessage
 import org.typelevel.log4cats.slf4j.internal.JTestLogger.TestLogMessage
 
 import java.util
+import java.util.concurrent.{Executors, ThreadFactory}
 import java.util.function
 import java.util.function.{BiConsumer, BinaryOperator, Supplier}
 import java.util.stream.Collector
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-import scala.concurrent.ExecutionContext
-import scala.concurrent.ExecutionContextExecutorService
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 import scala.util.control.NoStackTrace
 
 class Slf4jLoggerInternalSuite extends CatsEffectSuite {


### PR DESCRIPTION
My attempt at solving #868. 

- Populate the MDC even if isEnabled resolves in `false`
  - This is tested by implementing a TestLogger that will update some state with the current MDC value every time the `<level>isEnabled` is checked, to assert it is updated even if the check resolves to false
- Changed the error handling to be more functional
  - not sure if this will impact performance? It will result in a few more flatMaps.